### PR TITLE
feat: Add Chatwoot AI Agent tools

### DIFF
--- a/nodes/ChatWoot/ChatWoot.node.ts
+++ b/nodes/ChatWoot/ChatWoot.node.ts
@@ -1,6 +1,10 @@
-import {INodeType, INodeTypeDescription} from 'n8n-workflow';
+import {AITool, INodeType, INodeTypeDescription} from 'n8n-workflow';
 import {N8NPropertiesBuilder, N8NPropertiesBuilderConfig} from '@devlikeapro/n8n-openapi-node';
 import * as doc from './openapi.json';
+import {AssignConversation} from './tools/assignConversation';
+import {AddTag} from './tools/addTag';
+import {SendSummary} from './tools/sendSummary';
+import {AddNote} from './tools/addNote';
 
 const config: N8NPropertiesBuilderConfig = {}
 const parser = new N8NPropertiesBuilder(doc, config);
@@ -35,4 +39,11 @@ export class ChatWoot implements INodeType {
         },
         properties: properties,
     };
+
+    tools: AITool[] = [
+        new AssignConversation(),
+        new AddTag(),
+        new SendSummary(),
+        new AddNote(),
+    ];
 }

--- a/nodes/ChatWoot/tools/addNote.ts
+++ b/nodes/ChatWoot/tools/addNote.ts
@@ -1,0 +1,47 @@
+import {AITool, ToolInput} from 'n8n-workflow';
+
+export class AddNote implements AITool {
+	name = 'addNote';
+	description = 'Add a private note to a conversation';
+
+	inputs: ToolInput[] = [
+		{
+			name: 'accountId',
+			description: 'The numeric ID of the account',
+			type: 'number',
+			required: true,
+		},
+		{
+			name: 'conversationId',
+			description: 'The numeric ID of the conversation',
+			type: 'number',
+			required: true,
+		},
+		{
+			name: 'note',
+			description: 'The private note to be added',
+			type: 'string',
+			required: true,
+		},
+	];
+
+	async run(inputs: Record<string, any>): Promise<any> {
+		// @ts-ignore
+		const credentials = await this.getCredentials('chatwootApi');
+		const baseUrl = credentials.url;
+		const response = await this.helpers.request({
+			method: 'POST',
+			url: `${baseUrl}/api/v1/accounts/${inputs.accountId}/conversations/${inputs.conversationId}/messages`,
+			headers: {
+				'api_access_token': credentials.apiKey,
+			},
+			body: {
+				content: inputs.note,
+				message_type: 'outgoing',
+				private: true,
+			},
+			json: true,
+		});
+		return response;
+	}
+}

--- a/nodes/ChatWoot/tools/addTag.ts
+++ b/nodes/ChatWoot/tools/addTag.ts
@@ -1,0 +1,45 @@
+import {AITool, ToolInput} from 'n8n-workflow';
+
+export class AddTag implements AITool {
+	name = 'addTag';
+	description = 'Add tags (labels) to a conversation';
+
+	inputs: ToolInput[] = [
+		{
+			name: 'accountId',
+			description: 'The numeric ID of the account',
+			type: 'number',
+			required: true,
+		},
+		{
+			name: 'conversationId',
+			description: 'The numeric ID of the conversation',
+			type: 'number',
+			required: true,
+		},
+		{
+			name: 'tags',
+			description: 'Array of labels (comma-separated strings)',
+			type: 'string',
+			required: true,
+		},
+	];
+
+	async run(inputs: Record<string, any>): Promise<any> {
+		// @ts-ignore
+		const credentials = await this.getCredentials('chatwootApi');
+		const baseUrl = credentials.url;
+		const response = await this.helpers.request({
+			method: 'POST',
+			url: `${baseUrl}/api/v1/accounts/${inputs.accountId}/conversations/${inputs.conversationId}/labels`,
+			headers: {
+				'api_access_token': credentials.apiKey,
+			},
+			body: {
+				labels: inputs.tags.split(','),
+			},
+			json: true,
+		});
+		return response;
+	}
+}

--- a/nodes/ChatWoot/tools/assignConversation.ts
+++ b/nodes/ChatWoot/tools/assignConversation.ts
@@ -1,0 +1,50 @@
+import {AITool, ToolInput} from 'n8n-workflow';
+
+export class AssignConversation implements AITool {
+	name = 'assignConversation';
+	description = 'Assign a conversation to an agent or a team';
+
+	inputs: ToolInput[] = [
+		{
+			name: 'accountId',
+			description: 'The numeric ID of the account',
+			type: 'number',
+			required: true,
+		},
+		{
+			name: 'conversationId',
+			description: 'The numeric ID of the conversation',
+			type: 'number',
+			required: true,
+		},
+		{
+			name: 'assigneeId',
+			description: 'Id of the assignee user',
+			type: 'number',
+		},
+		{
+			name: 'teamId',
+			description: 'Id of the team. If the assignee_id is present, this param would be ignored',
+			type: 'number',
+		},
+	];
+
+	async run(inputs: Record<string, any>): Promise<any> {
+		// @ts-ignore
+		const credentials = await this.getCredentials('chatwootApi');
+		const baseUrl = credentials.url;
+		const response = await this.helpers.request({
+			method: 'POST',
+			url: `${baseUrl}/api/v1/accounts/${inputs.accountId}/conversations/${inputs.conversationId}/assignments`,
+			headers: {
+				'api_access_token': credentials.apiKey,
+			},
+			body: {
+				assignee_id: inputs.assigneeId,
+				team_id: inputs.teamId,
+			},
+			json: true,
+		});
+		return response;
+	}
+}

--- a/nodes/ChatWoot/tools/sendSummary.ts
+++ b/nodes/ChatWoot/tools/sendSummary.ts
@@ -1,0 +1,47 @@
+import {AITool, ToolInput} from 'n8n-workflow';
+
+export class SendSummary implements AITool {
+	name = 'sendSummary';
+	description = 'Send a summary message to a conversation';
+
+	inputs: ToolInput[] = [
+		{
+			name: 'accountId',
+			description: 'The numeric ID of the account',
+			type: 'number',
+			required: true,
+		},
+		{
+			name: 'conversationId',
+			description: 'The numeric ID of the conversation',
+			type: 'number',
+			required: true,
+		},
+		{
+			name: 'message',
+			description: 'The summary message to be sent',
+			type: 'string',
+			required: true,
+		},
+	];
+
+	async run(inputs: Record<string, any>): Promise<any> {
+		// @ts-ignore
+		const credentials = await this.getCredentials('chatwootApi');
+		const baseUrl = credentials.url;
+		const response = await this.helpers.request({
+			method: 'POST',
+			url: `${baseUrl}/api/v1/accounts/${inputs.accountId}/conversations/${inputs.conversationId}/messages`,
+			headers: {
+				'api_access_token': credentials.apiKey,
+			},
+			body: {
+				content: inputs.message,
+				message_type: 'outgoing',
+				private: false,
+			},
+			json: true,
+		});
+		return response;
+	}
+}


### PR DESCRIPTION
This commit introduces AI Agent tools for the existing Chatwoot node.

The following tools have been added:
- Assign Conversation
- Add Tag
- Send Summary
- Add Note

These tools replicate the functionality of the existing Chatwoot nodes, but are designed to be used within the AI Agent node.